### PR TITLE
Correct configuration.nix section for protonup in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ nix shell nixpkgs#pciutils -c lspci | grep ' VGA '"
     protonup
   ];
   
-  home.sessionVariables = {
+  environment.sessionVariables = {
     STEAM_EXTRA_COMPAT_TOOLS_PATHS =
       "\${HOME}/.steam/root/compatibilitytools.d";
   };


### PR DESCRIPTION
Both the configuration.nix and the home.nix version for the protonup section refer to home.sessionVariables while the configuration.nix section should refer to environment.sessionVariables